### PR TITLE
Fix issue with duplicate headers in WSGI environment

### DIFF
--- a/chocs/http_headers.py
+++ b/chocs/http_headers.py
@@ -83,6 +83,7 @@ class HttpHeaders:
         for key, values in self._headers.items():
             if len(values) == 1:
                 yield key, values[0]
+                continue
             for value in values:
                 yield key, value
 

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -7,11 +7,17 @@ from chocs.wsgi import create_wsgi_handler
 
 def test_create_wsgi_handler() -> None:
     def _http_start(status_code, headers):
+        assert headers == [
+            ("content-type", "text/plain"),
+        ]
         assert status_code == "200"
 
     def _serve_response(request: HttpRequest, next: Callable) -> HttpResponse:
         assert request.method == HttpMethod.POST
-        return HttpResponse("OK")
+        return HttpResponse(
+            "OK",
+            headers=request.headers
+        )
 
     app = Application(_serve_response)
     handler = create_wsgi_handler(app)


### PR DESCRIPTION
I spotted an issue in my local wsgi environment with duplicate headers. I think the issue is with the `items` method on HttpHeaders. If you step through the code, you can see that it yields and then continues to `for value in values` and duplicates the header.

I'm not sure why this hasn't shown itself before now - I can only assume that somehow the duplication is removed during the AWS processing.