### PR TITLE
Handle JsonReferences in query parameters

### DIFF
--- a/chocs/middleware/open_api_middleware.py
+++ b/chocs/middleware/open_api_middleware.py
@@ -4,7 +4,7 @@ from typing import Callable, Dict
 from chocs.http_method import HttpMethod
 from chocs.http_request import HttpRequest
 from chocs.http_response import HttpResponse
-from chocs.json_schema.json_schema import OpenApiSchema
+from chocs.json_schema.json_schema import JsonReference, OpenApiSchema
 from chocs.json_schema.schema_validator import build_validator_from_schema
 from chocs.middleware import Middleware, MiddlewareHandler
 from chocs.routing import Route
@@ -62,6 +62,8 @@ class OpenApiMiddleware(Middleware):
                     "required": [],
                 }
                 for param in query_parameters:
+                    if isinstance(param, JsonReference):
+                        param = param.data
                     param_name = param.get("name", "_")
                     query_schema["properties"][param_name] = param["schema"]  # type:ignore
                     if param["required"]:

--- a/tests/fixtures/openapi.yml
+++ b/tests/fixtures/openapi.yml
@@ -38,6 +38,7 @@ paths:
           schema:
             type: integer
             format: int32
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: pet response
@@ -122,6 +123,16 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 components:
+  parameters:
+    offset:
+      required: false
+      in: query
+      name: offset
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+
   schemas:
     Pet:
       allOf:


### PR DESCRIPTION
I noticed in one of my APIs that uses JsonReferences for query parameters that I was getting a crash with query validation switched on. The fix seems pretty simple - just check if the param is a reference, and if so set it to the reference's data.